### PR TITLE
Add minio as blob storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,6 @@ FodyWeavers.xsd
 *.sln.iml
 
 .DS_Store
+
+# local infrastructure storage
+tmp/*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-## build/test/run
+## basic operations
 
 build:
 	dotnet build ./code/csharp/Nebu
@@ -21,7 +21,7 @@ ef-migration:
 
 # composes dependencies
 compose-deps:
-	docker compose up --build -d db
+	docker compose up -d db minio
 
 # composes api and its dependencies
 compose-api:

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,6 +13,21 @@ services:
       timeout: 5s
       retries: 5
 
+  minio:
+    image: minio/minio:latest
+    entrypoint: sh
+    command: -c 'mkdir -p /data && /usr/bin/minio server --console-address ":9090" /data'
+    environment:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: password
+      MINIO_REGION: us-east-1
+      MINIO_DOMAIN: minio
+    ports:
+      - "9000:9000"
+      - "9090:9090"
+    volumes:
+      - ./tmp/minio/:/data
+
   api:
     build:
       context: ./code/csharp/Nebu
@@ -24,3 +39,5 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      minio:
+        condition: service_started


### PR DESCRIPTION
## Summary

Adds minio to the compose stack. It will be used as the local cloud blob storage target.

## Testing Strategy

Verified that the various compose commands work, this will be used for longer-term testing
