### PR TITLE
Add buckets and blobs as resources

### DIFF
--- a/code/csharp/Nebu/Nebu.Api/Controllers/BlobsController.cs
+++ b/code/csharp/Nebu/Nebu.Api/Controllers/BlobsController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using Nebu.Api.Models.Blobs;
+
+namespace Nebu.Api.Controllers;
+
+[ApiController]
+[Route("api/buckets/{bucketId}/[controller]")]
+public class BlobsController(IBlobService _blobService) : ControllerBase
+{
+    [HttpGet]
+    public Task<IEnumerable<BlobReadModel>> ListBlobs([FromRoute] Guid bucketId)
+    {
+        return _blobService.ListBlobs(bucketId);
+    }
+
+    [HttpPost]
+    [ProducesResponseType<BlobReadModel>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> CreateBlob([FromRoute] Guid bucketId, [FromBody] BlobWriteModel b)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        var result = await _blobService.CreateBlob(bucketId, b);
+        return Ok(result);
+    }
+}
+

--- a/code/csharp/Nebu/Nebu.Api/Controllers/BucketsController.cs
+++ b/code/csharp/Nebu/Nebu.Api/Controllers/BucketsController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using Nebu.Api.Models.Buckets;
+
+namespace Nebu.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class BucketsController(IBucketService _bucketService) : ControllerBase
+{
+    [HttpGet]
+    public Task<IEnumerable<BucketReadModel>> ListBuckets([FromHeader] Guid userId)
+    {
+        return _bucketService.ListBuckets(userId);
+    }
+
+    [HttpPost]
+    [ProducesResponseType<BucketReadModel>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> CreateBucket([FromHeader] Guid userId, [FromBody] BucketWriteModel b)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        var result = await _bucketService.CreateBucket(userId, b);
+        return Ok(result);
+    }
+}
+

--- a/code/csharp/Nebu/Nebu.Api/Controllers/UsersController.cs
+++ b/code/csharp/Nebu/Nebu.Api/Controllers/UsersController.cs
@@ -1,6 +1,4 @@
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
-using Nebu.Api.Ef;
 using Nebu.Api.Models.Users;
 
 namespace Nebu.Api.Controllers;

--- a/code/csharp/Nebu/Nebu.Api/Ef/EfBlob.cs
+++ b/code/csharp/Nebu/Nebu.Api/Ef/EfBlob.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Nebu.Api.Ef;
+
+[Table("Blobs")]
+public class EfBlob
+{
+    [Key, DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public Guid Id { get; set; }
+
+    public Guid BucketId { get; set; }
+    public EfBucket? Bucket { get; set; }
+
+    public required string Key { get; set; }
+}

--- a/code/csharp/Nebu/Nebu.Api/Ef/EfBucket.cs
+++ b/code/csharp/Nebu/Nebu.Api/Ef/EfBucket.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Nebu.Api.Ef;
+
+[Table("Buckets")]
+public class EfBucket
+{
+    [Key, DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public Guid Id { get; set; }
+
+    public Guid UserId { get; set; }
+    public EfUser? User { get; set; }
+
+    public required string Uri { get; set; }
+
+    public ICollection<EfBlob>? Blobs { get; set; }
+}

--- a/code/csharp/Nebu/Nebu.Api/Ef/EfUser.cs
+++ b/code/csharp/Nebu/Nebu.Api/Ef/EfUser.cs
@@ -12,4 +12,6 @@ public class EfUser
     public Guid Id { get; set; }
     public string Name { get; set; } = "";
     public string? ApiKey { get; set; }
+
+    public ICollection<EfBucket>? Buckets { get; set; }
 }

--- a/code/csharp/Nebu/Nebu.Api/Ef/NebuContext.cs
+++ b/code/csharp/Nebu/Nebu.Api/Ef/NebuContext.cs
@@ -5,4 +5,23 @@ namespace Nebu.Api.Ef;
 public class NebuContext(DbContextOptions options) : DbContext(options)
 {
     public DbSet<EfUser> Users { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<EfUser>()
+            .HasMany(a => a.Buckets)
+            .WithOne(a => a.User)
+            .HasForeignKey(a => a.UserId)
+            .HasPrincipalKey(a => a.Id)
+            .OnDelete(DeleteBehavior.NoAction);
+
+        modelBuilder.Entity<EfBucket>()
+            .HasMany(a => a.Blobs)
+            .WithOne(a => a.Bucket)
+            .HasForeignKey(a => a.BucketId)
+            .HasPrincipalKey(a => a.Id)
+            .OnDelete(DeleteBehavior.NoAction);
+
+        base.OnModelCreating(modelBuilder);
+    }
 }

--- a/code/csharp/Nebu/Nebu.Api/Migrations/20231126025946_BucketsAndBlobs.Designer.cs
+++ b/code/csharp/Nebu/Nebu.Api/Migrations/20231126025946_BucketsAndBlobs.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nebu.Api.Ef;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nebu.Api.Migrations
 {
     [DbContext(typeof(NebuContext))]
-    partial class NebuContextModelSnapshot : ModelSnapshot
+    [Migration("20231126025946_BucketsAndBlobs")]
+    partial class BucketsAndBlobs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/code/csharp/Nebu/Nebu.Api/Migrations/20231126025946_BucketsAndBlobs.cs
+++ b/code/csharp/Nebu/Nebu.Api/Migrations/20231126025946_BucketsAndBlobs.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nebu.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class BucketsAndBlobs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Buckets",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Uri = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Buckets", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Buckets_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Blobs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    BucketId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Key = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Blobs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Blobs_Buckets_BucketId",
+                        column: x => x.BucketId,
+                        principalTable: "Buckets",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Blobs_BucketId",
+                table: "Blobs",
+                column: "BucketId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Buckets_UserId",
+                table: "Buckets",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Blobs");
+
+            migrationBuilder.DropTable(
+                name: "Buckets");
+        }
+    }
+}

--- a/code/csharp/Nebu/Nebu.Api/Models/Blobs/Blob.cs
+++ b/code/csharp/Nebu/Nebu.Api/Models/Blobs/Blob.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Nebu.Api.Models.Blobs;
+
+public record BlobReadModel(
+    Guid Id,
+    Guid BucketId,
+    string Key)
+{
+}
+
+public record BlobWriteModel
+{
+    [Required]
+    public string? Key { get; set; }
+}

--- a/code/csharp/Nebu/Nebu.Api/Models/Blobs/Interfaces.cs
+++ b/code/csharp/Nebu/Nebu.Api/Models/Blobs/Interfaces.cs
@@ -1,0 +1,7 @@
+namespace Nebu.Api.Models.Blobs;
+
+public interface IBlobService
+{
+    Task<IEnumerable<BlobReadModel>> ListBlobs(Guid bucketId);
+    Task<BlobReadModel> CreateBlob(Guid bucketId, BlobWriteModel m);
+}

--- a/code/csharp/Nebu/Nebu.Api/Models/Buckets/Bucket.cs
+++ b/code/csharp/Nebu/Nebu.Api/Models/Buckets/Bucket.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Nebu.Api.Models.Buckets;
+
+public record BucketReadModel(
+    Guid Id,
+    Guid UserId,
+    string Uri
+)
+{ }
+
+public class BucketWriteModel
+{
+    [Required]
+    public string? Uri { get; set; }
+}

--- a/code/csharp/Nebu/Nebu.Api/Models/Buckets/Interfaces.cs
+++ b/code/csharp/Nebu/Nebu.Api/Models/Buckets/Interfaces.cs
@@ -1,0 +1,7 @@
+namespace Nebu.Api.Models.Buckets;
+
+public interface IBucketService
+{
+    Task<IEnumerable<BucketReadModel>> ListBuckets(Guid userId);
+    Task<BucketReadModel> CreateBucket(Guid userId, BucketWriteModel m);
+}

--- a/code/csharp/Nebu/Nebu.Api/Models/Users/Interfaces.cs
+++ b/code/csharp/Nebu/Nebu.Api/Models/Users/Interfaces.cs
@@ -2,6 +2,6 @@ namespace Nebu.Api.Models.Users;
 
 public interface IUserService
 {
-    public Task<IEnumerable<UserReadModel>> ListUsers();
+    Task<IEnumerable<UserReadModel>> ListUsers();
     Task<UserReadModel> CreateUser();
 }

--- a/code/csharp/Nebu/Nebu.Api/Program.cs
+++ b/code/csharp/Nebu/Nebu.Api/Program.cs
@@ -1,5 +1,8 @@
+using System.Reflection.Metadata;
 using Microsoft.EntityFrameworkCore;
 using Nebu.Api.Ef;
+using Nebu.Api.Models.Blobs;
+using Nebu.Api.Models.Buckets;
 using Nebu.Api.Models.Users;
 using Nebu.Api.Services;
 
@@ -11,6 +14,9 @@ builder.Services.AddDbContext<NebuContext>(o =>
     o.UseNpgsql(
         builder.Configuration.GetConnectionString("Nebu")));
 
+
+builder.Services.AddTransient<IBlobService, BlobService>();
+builder.Services.AddTransient<IBucketService, BucketService>();
 builder.Services.AddTransient<IUserService, UserService>();
 
 builder.Services.AddControllers();

--- a/code/csharp/Nebu/Nebu.Api/Services/BlobService.cs
+++ b/code/csharp/Nebu/Nebu.Api/Services/BlobService.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Nebu.Api.Ef;
+using Nebu.Api.Models.Blobs;
+
+namespace Nebu.Api.Services;
+
+public class BlobService(NebuContext _db) : IBlobService
+{
+    public async Task<BlobReadModel> CreateBlob(Guid bucketId, BlobWriteModel m)
+    {
+        var b = await _db.Set<EfBlob>()
+            .AddAsync(new EfBlob
+            {
+                BucketId = bucketId,
+                Key = m.Key!
+            });
+        await _db.SaveChangesAsync();
+
+        return ToReadModel(b.Entity);
+    }
+
+    public async Task<IEnumerable<BlobReadModel>> ListBlobs(Guid bucketId)
+    {
+        return await _db.Set<EfBlob>()
+            .Where(b => b.BucketId == bucketId)
+            .Select(b => ToReadModel(b))
+            .ToListAsync();
+    }
+
+    private static BlobReadModel ToReadModel(EfBlob b)
+        => new(b.Id, b.BucketId, b.Key);
+}

--- a/code/csharp/Nebu/Nebu.Api/Services/BucketService.cs
+++ b/code/csharp/Nebu/Nebu.Api/Services/BucketService.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Nebu.Api.Ef;
+using Nebu.Api.Models.Buckets;
+
+namespace Nebu.Api.Services;
+
+public class BucketService(NebuContext _db) : IBucketService
+{
+    public async Task<BucketReadModel> CreateBucket(Guid userId, BucketWriteModel m)
+    {
+        var b = await _db.Set<EfBucket>()
+            .AddAsync(new EfBucket
+            {
+                UserId = userId,
+                Uri = m.Uri!
+            });
+        await _db.SaveChangesAsync();
+
+        return ToReadModel(b.Entity);
+    }
+
+    public async Task<IEnumerable<BucketReadModel>> ListBuckets(Guid userId)
+    {
+        return await _db.Set<EfBucket>()
+            .Where(b => b.UserId == userId)
+            .Select(a => ToReadModel(a))
+            .ToListAsync();
+    }
+
+    private static BucketReadModel ToReadModel(EfBucket b)
+        => new(b.Id, b.UserId, b.Uri);
+}

--- a/code/csharp/Nebu/Nebu.Api/Services/UserService.cs
+++ b/code/csharp/Nebu/Nebu.Api/Services/UserService.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Nebu.Api.Ef;
 using Nebu.Api.Models.Users;
@@ -9,16 +8,19 @@ public class UserService(NebuContext _db) : IUserService
 {
     public async Task<IEnumerable<UserReadModel>> ListUsers()
     {
-        return await _db.Set<EfUser>().Select(u => ToReadModel(u)).ToListAsync();
+        return await _db.Set<EfUser>()
+            .Select(u => ToReadModel(u))
+            .ToListAsync();
     }
 
     public async Task<UserReadModel> CreateUser()
     {
-        var u = await _db.Set<EfUser>().AddAsync(new EfUser
-        {
-            Name = "Test user",
-            ApiKey = Guid.NewGuid().ToString()
-        });
+        var u = await _db.Set<EfUser>()
+            .AddAsync(new EfUser
+            {
+                Name = "Test user",
+                ApiKey = Guid.NewGuid().ToString()
+            });
         await _db.SaveChangesAsync();
 
         return ToReadModel(u.Entity);


### PR DESCRIPTION
## Summary

Scaffolds buckets and blobs as API resources. Buckets are bound to users, blobs are bound to buckets.

No auth as of yet, just setting up resource relationships. 

## Testing Strategy
Manual API exercising. Automated tests will start coming in after a blob is stored and retrieved in a store.

